### PR TITLE
throwing custom error on database connection problems.

### DIFF
--- a/ChatMail.UnitTests/DBConnectorTest.cs
+++ b/ChatMail.UnitTests/DBConnectorTest.cs
@@ -6,6 +6,7 @@ using ChatMail.Models;
 using System.IO;
 using Newtonsoft.Json;
 using MySql.Data.MySqlClient;
+using ChatMail.Exceptions;
 
 namespace ChatMail.UnitTests
 {
@@ -39,7 +40,7 @@ namespace ChatMail.UnitTests
             invalidConfig.Port += 10;
             DBConnector db = new DBConnector(invalidConfig);
 
-            Assert.ThrowsException<MySqlException>(db.Open);
+            Assert.ThrowsException<DatabaseConnectionError>(db.Open);
         }
 
         [TestMethod]

--- a/ChatMail/Database/DBConnector.cs
+++ b/ChatMail/Database/DBConnector.cs
@@ -8,6 +8,7 @@ using System.Data;
 using System.Diagnostics;
 using ChatMail.Models;
 using ChatMail.Logging;
+using ChatMail.Exceptions;
 
 namespace ChatMail.Database
 {
@@ -53,23 +54,38 @@ namespace ChatMail.Database
         /// <summary>
         /// Opens database connection if closed
         /// </summary>
+        /// <exception cref="ChatMail.Exceptions.DatabaseConnectionError">Throws when connection could not be established.</exception>
         public void Open()
         {
             if(this.connection.State == ConnectionState.Closed)
             {
                 Logger.debug("Opening connection.", "ChatMail.Database.Connector");
-                connection.Open();
+                try
+                {
+                    connection.Open();
+                } catch (MySqlException ex)
+                {
+                    throw new DatabaseConnectionError("Could not connect to database.", ex);
+                }
             }
         }
         /// <summary>
         /// Closes database connection if opened
         /// </summary>
+        /// <exception cref="ChatMail.Exceptions.DatabaseConnectionError">Throws when connection could not be closed.</exception>
         public void Close()
         {
             if (this.connection.State == ConnectionState.Open)
             {
                 Logger.debug("Closing connection.", "ChatMail.Database.Connector");
-                connection.Close();
+                try
+                {
+                    connection.Close();
+                }
+                catch (MySqlException ex)
+                {
+                    throw new DatabaseConnectionError("Could not disconnect from database.", ex);
+                }
             }
         }
         /// <summary>
@@ -77,6 +93,7 @@ namespace ChatMail.Database
         /// </summary>
         /// <param name="sql">sql clause</param>
         /// <returns>Fetched Datatable</returns>
+        /// <exception cref="ChatMail.Exceptions.DatabaseConnectionError">Throws when query could not be executed successfully.</exception>
         public DataTable Execute(string sql)
         {
             Logger.info("Executing \"" + sql + "\".", "ChatMail.Database.Connector");
@@ -99,6 +116,7 @@ namespace ChatMail.Database
         /// </summary>
         /// <param name="command">MySqlCommand to execute</param>
         /// <returns>Fetched Datatable</returns>
+        /// <exception cref="ChatMail.Exceptions.DatabaseConnectionError">Throws when query could not be executed successfully.</exception>
         public DataTable Execute(MySqlCommand command)
         {
             Logger.info("Executing \"" + command.CommandText + "\".", "ChatMail.Database.Connector");
@@ -117,6 +135,7 @@ namespace ChatMail.Database
         /// </summary>
         /// <param name="command">MySqlCommand to execute</param>
         /// <returns>Count of affected rows</returns>
+        /// <exception cref="ChatMail.Exceptions.DatabaseConnectionError">Throws when query could not be executed successfully.</exception>
         public int ExecuteNonQuery(MySqlCommand command)
         {
             Logger.info("Executing \"" + command.CommandText + "\".", "ChatMail.Database.Connector");

--- a/ChatMail/Database/DBConnector.cs
+++ b/ChatMail/Database/DBConnector.cs
@@ -65,6 +65,7 @@ namespace ChatMail.Database
                     connection.Open();
                 } catch (MySqlException ex)
                 {
+                    Logger.critical("Could not connect to database.\n" + ex.Message, "ChatMail.Database.Connector");
                     throw new DatabaseConnectionError("Could not connect to database.", ex);
                 }
             }
@@ -84,6 +85,7 @@ namespace ChatMail.Database
                 }
                 catch (MySqlException ex)
                 {
+                    Logger.critical("Could not disconnect from database.\n" + ex.Message, "ChatMail.Database.Connector");
                     throw new DatabaseConnectionError("Could not disconnect from database.", ex);
                 }
             }
@@ -93,7 +95,8 @@ namespace ChatMail.Database
         /// </summary>
         /// <param name="sql">sql clause</param>
         /// <returns>Fetched Datatable</returns>
-        /// <exception cref="ChatMail.Exceptions.DatabaseConnectionError">Throws when query could not be executed successfully.</exception>
+        /// <exception cref="ChatMail.Exceptions.DatabaseConnectionError">Throws when a connection error occures.</exception>
+        /// <exception cref="MySqlException">Throws when query could not be executed successfully.</exception>
         public DataTable Execute(string sql)
         {
             Logger.info("Executing \"" + sql + "\".", "ChatMail.Database.Connector");
@@ -116,7 +119,8 @@ namespace ChatMail.Database
         /// </summary>
         /// <param name="command">MySqlCommand to execute</param>
         /// <returns>Fetched Datatable</returns>
-        /// <exception cref="ChatMail.Exceptions.DatabaseConnectionError">Throws when query could not be executed successfully.</exception>
+        /// <exception cref="ChatMail.Exceptions.DatabaseConnectionError">Throws when a connection error occures.</exception>
+        /// <exception cref="MySqlException">Throws when query could not be executed successfully.</exception>
         public DataTable Execute(MySqlCommand command)
         {
             Logger.info("Executing \"" + command.CommandText + "\".", "ChatMail.Database.Connector");
@@ -135,7 +139,8 @@ namespace ChatMail.Database
         /// </summary>
         /// <param name="command">MySqlCommand to execute</param>
         /// <returns>Count of affected rows</returns>
-        /// <exception cref="ChatMail.Exceptions.DatabaseConnectionError">Throws when query could not be executed successfully.</exception>
+        /// <exception cref="ChatMail.Exceptions.DatabaseConnectionError">Throws when a connection error occures.</exception>
+        /// <exception cref="MySqlException">Throws when query could not be executed successfully.</exception>
         public int ExecuteNonQuery(MySqlCommand command)
         {
             Logger.info("Executing \"" + command.CommandText + "\".", "ChatMail.Database.Connector");

--- a/ChatMail/Database/DBHandler.cs
+++ b/ChatMail/Database/DBHandler.cs
@@ -49,7 +49,8 @@ namespace ChatMail.Database
         /// Gets list of all registered users
         /// </summary>
         /// <returns>List of user objects</returns>
-        /// <exception cref="ChatMail.Exceptions.DatabaseConnectionError">Throws when query could not be executed successfully.</exception>
+        /// <exception cref="ChatMail.Exceptions.DatabaseConnectionError">Throws when a connection error occures.</exception>
+        /// <exception cref="MySqlException">Throws when query could not be executed successfully.</exception>
         public List<User> GetAllUsers()
         {
             Logger.debug("Selecting all users.", "ChatMail.Database.Handler");
@@ -71,7 +72,8 @@ namespace ChatMail.Database
         /// </summary>
         /// <param name="uId">User id to search for</param>
         /// <returns>User object, null if not found</returns>
-        /// <exception cref="ChatMail.Exceptions.DatabaseConnectionError">Throws when query could not be executed successfully.</exception>
+        /// <exception cref="ChatMail.Exceptions.DatabaseConnectionError">Throws when a connection error occures.</exception>
+        /// <exception cref="MySqlException">Throws when query could not be executed successfully.</exception>
         public User GetUserByUserId(int uId)
         {
             Logger.debug("Selecting user by uId \"" + uId + "\".", "ChatMail.Database.Handler");
@@ -95,7 +97,8 @@ namespace ChatMail.Database
         /// Gets a list of all sent messages
         /// </summary>
         /// <returns>List of all message objects</returns>
-        /// <exception cref="ChatMail.Exceptions.DatabaseConnectionError">Throws when query could not be executed successfully.</exception>
+        /// <exception cref="ChatMail.Exceptions.DatabaseConnectionError">Throws when a connection error occures.</exception>
+        /// <exception cref="MySqlException">Throws when query could not be executed successfully.</exception>
         public List<Message> GetAllMessages()
         {
             Logger.debug("Selecting all messages.", "ChatMail.Database.Handler");
@@ -121,7 +124,8 @@ namespace ChatMail.Database
         /// </summary>
         /// <param name="rId">ID of user that received messages</param>
         /// <returns>List of message objects sent to the user</returns>
-        /// <exception cref="ChatMail.Exceptions.DatabaseConnectionError">Throws when query could not be executed successfully.</exception>
+        /// <exception cref="ChatMail.Exceptions.DatabaseConnectionError">Throws when a connection error occures.</exception>
+        /// <exception cref="MySqlException">Throws when query could not be executed successfully.</exception>
         public List<Message> GetMessagesByReceiverId(int rId)
         {
             Logger.debug("Selecting all messages by rId \"" + rId + "\".", "ChatMail.Database.Handler");
@@ -151,7 +155,8 @@ namespace ChatMail.Database
         /// </summary>
         /// <param name="mId">message id to search for</param>
         /// <returns>Message object, null if not found</returns>
-        /// <exception cref="ChatMail.Exceptions.DatabaseConnectionError">Throws when query could not be executed successfully.</exception>
+        /// <exception cref="ChatMail.Exceptions.DatabaseConnectionError">Throws when a connection error occures.</exception>
+        /// <exception cref="MySqlException">Throws when query could not be executed successfully.</exception>
         public Message GetMessageByMessageId(int mId)
         {
             Logger.debug("Selecting all messages by mId \"" + mId + "\".", "ChatMail.Database.Handler");
@@ -179,7 +184,8 @@ namespace ChatMail.Database
         /// </summary>
         /// <param name="mId">Message ID to scan</param>
         /// <returns>List of all receivers of this message</returns>
-        /// <exception cref="ChatMail.Exceptions.DatabaseConnectionError">Throws when query could not be executed successfully.</exception>
+        /// <exception cref="ChatMail.Exceptions.DatabaseConnectionError">Throws when a connection error occures.</exception>
+        /// <exception cref="MySqlException">Throws when query could not be executed successfully.</exception>
         public List<User> GetReceiversByMessageId(int mId)
         {
             Logger.debug("Selecting all receivers by mId \"" + mId + "\".", "ChatMail.Database.Handler");
@@ -206,7 +212,8 @@ namespace ChatMail.Database
         /// <param name="mId"></param>
         /// <param name="rId"></param>
         /// <returns></returns>
-        /// <exception cref="ChatMail.Exceptions.DatabaseConnectionError">Throws when query could not be executed successfully.</exception>
+        /// <exception cref="ChatMail.Exceptions.DatabaseConnectionError">Throws when a connection error occures.</exception>
+        /// <exception cref="MySqlException">Throws when query could not be executed successfully.</exception>
         private bool InsertMessageReceiver(int mId, int rId)
         {
             Logger.debug("Inserting MessageReceiver relation.", "ChatMail.Database.Handler");
@@ -235,7 +242,8 @@ namespace ChatMail.Database
         /// </summary>
         /// <param name="message">Message object to insert</param>
         /// <returns>info about success</returns>
-        /// <exception cref="ChatMail.Exceptions.DatabaseConnectionError">Throws when query could not be executed successfully.</exception>
+        /// <exception cref="ChatMail.Exceptions.DatabaseConnectionError">Throws when a connection error occures.</exception>
+        /// <exception cref="MySqlException">Throws when query could not be executed successfully.</exception>
         public bool InsertMessage(Message message)
         {
             Logger.debug("Inserting Message.", "ChatMail.Database.Handler");
@@ -289,7 +297,8 @@ namespace ChatMail.Database
         /// </summary>
         /// <param name="user">User object ot insert</param>
         /// <returns>Info about success</returns>
-        /// <exception cref="ChatMail.Exceptions.DatabaseConnectionError">Throws when query could not be executed successfully.</exception>
+        /// <exception cref="ChatMail.Exceptions.DatabaseConnectionError">Throws when a connection error occures.</exception>
+        /// <exception cref="MySqlException">Throws when query could not be executed successfully.</exception>
         public bool InsertUser(User user)
         {
             Logger.debug("Inserting User.", "ChatMail.Database.Handler");

--- a/ChatMail/Database/DBHandler.cs
+++ b/ChatMail/Database/DBHandler.cs
@@ -49,6 +49,7 @@ namespace ChatMail.Database
         /// Gets list of all registered users
         /// </summary>
         /// <returns>List of user objects</returns>
+        /// <exception cref="ChatMail.Exceptions.DatabaseConnectionError">Throws when query could not be executed successfully.</exception>
         public List<User> GetAllUsers()
         {
             Logger.debug("Selecting all users.", "ChatMail.Database.Handler");
@@ -70,6 +71,7 @@ namespace ChatMail.Database
         /// </summary>
         /// <param name="uId">User id to search for</param>
         /// <returns>User object, null if not found</returns>
+        /// <exception cref="ChatMail.Exceptions.DatabaseConnectionError">Throws when query could not be executed successfully.</exception>
         public User GetUserByUserId(int uId)
         {
             Logger.debug("Selecting user by uId \"" + uId + "\".", "ChatMail.Database.Handler");
@@ -93,6 +95,7 @@ namespace ChatMail.Database
         /// Gets a list of all sent messages
         /// </summary>
         /// <returns>List of all message objects</returns>
+        /// <exception cref="ChatMail.Exceptions.DatabaseConnectionError">Throws when query could not be executed successfully.</exception>
         public List<Message> GetAllMessages()
         {
             Logger.debug("Selecting all messages.", "ChatMail.Database.Handler");
@@ -118,6 +121,7 @@ namespace ChatMail.Database
         /// </summary>
         /// <param name="rId">ID of user that received messages</param>
         /// <returns>List of message objects sent to the user</returns>
+        /// <exception cref="ChatMail.Exceptions.DatabaseConnectionError">Throws when query could not be executed successfully.</exception>
         public List<Message> GetMessagesByReceiverId(int rId)
         {
             Logger.debug("Selecting all messages by rId \"" + rId + "\".", "ChatMail.Database.Handler");
@@ -147,6 +151,7 @@ namespace ChatMail.Database
         /// </summary>
         /// <param name="mId">message id to search for</param>
         /// <returns>Message object, null if not found</returns>
+        /// <exception cref="ChatMail.Exceptions.DatabaseConnectionError">Throws when query could not be executed successfully.</exception>
         public Message GetMessageByMessageId(int mId)
         {
             Logger.debug("Selecting all messages by mId \"" + mId + "\".", "ChatMail.Database.Handler");
@@ -174,6 +179,7 @@ namespace ChatMail.Database
         /// </summary>
         /// <param name="mId">Message ID to scan</param>
         /// <returns>List of all receivers of this message</returns>
+        /// <exception cref="ChatMail.Exceptions.DatabaseConnectionError">Throws when query could not be executed successfully.</exception>
         public List<User> GetReceiversByMessageId(int mId)
         {
             Logger.debug("Selecting all receivers by mId \"" + mId + "\".", "ChatMail.Database.Handler");
@@ -200,6 +206,7 @@ namespace ChatMail.Database
         /// <param name="mId"></param>
         /// <param name="rId"></param>
         /// <returns></returns>
+        /// <exception cref="ChatMail.Exceptions.DatabaseConnectionError">Throws when query could not be executed successfully.</exception>
         private bool InsertMessageReceiver(int mId, int rId)
         {
             Logger.debug("Inserting MessageReceiver relation.", "ChatMail.Database.Handler");
@@ -228,6 +235,7 @@ namespace ChatMail.Database
         /// </summary>
         /// <param name="message">Message object to insert</param>
         /// <returns>info about success</returns>
+        /// <exception cref="ChatMail.Exceptions.DatabaseConnectionError">Throws when query could not be executed successfully.</exception>
         public bool InsertMessage(Message message)
         {
             Logger.debug("Inserting Message.", "ChatMail.Database.Handler");
@@ -281,6 +289,7 @@ namespace ChatMail.Database
         /// </summary>
         /// <param name="user">User object ot insert</param>
         /// <returns>Info about success</returns>
+        /// <exception cref="ChatMail.Exceptions.DatabaseConnectionError">Throws when query could not be executed successfully.</exception>
         public bool InsertUser(User user)
         {
             Logger.debug("Inserting User.", "ChatMail.Database.Handler");

--- a/ChatMail/Exceptions/DatabaseConnectionError.cs
+++ b/ChatMail/Exceptions/DatabaseConnectionError.cs
@@ -1,0 +1,23 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace ChatMail.Exceptions
+{
+    [Serializable]
+    public class DatabaseConnectionError : Exception
+    {
+        public DatabaseConnectionError()
+        { }
+
+        public DatabaseConnectionError(string message)
+            : base(message)
+        { }
+
+        public DatabaseConnectionError(string message, Exception innerException)
+            : base(message, innerException)
+        { }
+    }
+}


### PR DESCRIPTION
catch `DatabaseConnectionError` as well as `MySQLException` to validate queries on success.
This can be used to get the chat running, even though the database connection could not be established